### PR TITLE
Fixed typing selects friend & does not input

### DIFF
--- a/src/components/FriendsList/FriendsListUserSearchBar.js
+++ b/src/components/FriendsList/FriendsListUserSearchBar.js
@@ -5,8 +5,13 @@ import { MenuItem, TextField, Tooltip } from "@material-ui/core";
 
 function FriendsListUserSearchBar(props) {
   const [text, updateText] = useState("");
-  const handleChange = (event) => {
+
+  const stopMenuPropagation = (event) => {
     event.stopPropagation();
+  };
+
+  const handleChange = (event) => {
+    stopMenuPropagation(event);
     updateText(event.target.value);
   };
 
@@ -37,6 +42,7 @@ function FriendsListUserSearchBar(props) {
           <TextField
             value={text}
             onChange={handleChange}
+            onKeyDown={stopMenuPropagation}
             margin="dense"
             placeholder="search users"
           />


### PR DESCRIPTION
Typing a username in the search bar was bugging out. If I had a friend whose name begins with "a" and I try to type the letter "a" in the search bar, it would select the friend and stop my typing.